### PR TITLE
Fix FileTest::testCanCreateUriObjectFromWindowsPath

### DIFF
--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -87,7 +87,7 @@ class FileTest extends TestCase
     public static function windowsUris()
     {
         return [
-            ['C:\Program Files\Laminas\README', 'C:/Program%20Files/Laminas%20Framework/README'],
+            ['C:\Program Files\Laminas\README', 'C:/Program%20Files/Laminas/README'],
         ];
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Just a typo fix in LaminasTest\Uri\FileTest::testCanCreateUriObjectFromWindowsPath

Travis job: https://travis-ci.org/laminas/laminas-uri/jobs/632064909
```
1) LaminasTest\Uri\FileTest::testCanCreateUriObjectFromWindowsPath with data set #0 ('C:\Program Files\Laminas\README', 'C:/Program%20Files/Laminas%20...README')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'C:/Program%20Files/Laminas%20Framework/README'
+'C:/Program%20Files/Laminas/README'
/home/travis/build/laminas/laminas-uri/test/FileTest.php:201
```

