### PR TITLE
rewrite testRegisteringNewScheme for 7.4

### DIFF
--- a/test/UriFactoryTest.php
+++ b/test/UriFactoryTest.php
@@ -29,11 +29,11 @@ class UriFactoryTest extends TestCase
      */
     public function testRegisteringNewScheme($scheme, $class)
     {
-        $this->assertAttributeNotContains($class, 'schemeClasses', '\Laminas\Uri\UriFactory');
+        $this->assertNull(UriFactory::getRegisteredSchemeClass($scheme));
         UriFactory::registerScheme($scheme, $class);
-        $this->assertAttributeContains($class, 'schemeClasses', '\Laminas\Uri\UriFactory');
+        $this->assertEquals(UriFactory::getRegisteredSchemeClass($scheme), $class);
         UriFactory::unregisterScheme($scheme);
-        $this->assertAttributeNotContains($class, 'schemeClasses', '\Laminas\Uri\UriFactory');
+        $this->assertNull(UriFactory::getRegisteredSchemeClass($scheme));
     }
 
     /**


### PR DESCRIPTION
With 7.4.2RC1, without this fix

```
There were 3 failures:

1) LaminasTest\Uri\UriFactoryTest::testRegisteringNewScheme with data set #0 ('ssh', 'Foo\Bar\Class')
Failed asserting that an array contains 'Foo\Bar\Class'.

/dev/shm/BUILD/laminas-uri-6be8ce19622f359b048ce4faebf1aa1bca73a7ff/test/UriFactoryTest.php:34

2) LaminasTest\Uri\UriFactoryTest::testRegisteringNewScheme with data set #1 ('ntp', 'No real class at all!!!')
Failed asserting that an array contains 'No real class at all!!!'.

/dev/shm/BUILD/laminas-uri-6be8ce19622f359b048ce4faebf1aa1bca73a7ff/test/UriFactoryTest.php:34

3) LaminasTest\Uri\UriFactoryTest::testUnknownSchemeThrowsException with data set #1 ('ssh://bar')
Failed asserting that exception of type "Error" matches expected exception "\Laminas\Uri\Exception\InvalidArgumentException". Message was: "Class 'Foo\Bar\Class' not found" at
/dev/shm/BUILDROOT/php-laminas-uri-2.7.1-1.fc31.remi.x86_64/usr/share/php/Laminas/Uri/UriFactory.php:110
/dev/shm/BUILD/laminas-uri-6be8ce19622f359b048ce4faebf1aa1bca73a7ff/test/UriFactoryTest.php:88

```