### PR TITLE
Ensure UriFactory works under PHP 8.1 when provided with a relative URI

### DIFF
--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -101,7 +101,7 @@ abstract class UriFactory
         }
 
         $uri    = new Uri($uriString);
-        $scheme = strtolower($uri->getScheme());
+        $scheme = strtolower($uri->getScheme() ?? '');
         if (! $scheme && $defaultScheme) {
             $scheme = $defaultScheme;
         }

--- a/test/UriFactoryTest.php
+++ b/test/UriFactoryTest.php
@@ -14,9 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class UriFactoryTest extends TestCase
 {
-    /**
-     * General composing / parsing tests
-     */
+    // General composing / parsing tests
 
     /**
      * Test registering a new Scheme
@@ -98,5 +96,12 @@ class UriFactoryTest extends TestCase
             ['foo://bar'],
             ['ssh://bar'],
         ];
+    }
+
+    public function testDoesNotRaiseErrorWhenOnlyPathProvided(): void
+    {
+        $path = '/path';
+        $uri  = UriFactory::factory($path);
+        $this->assertSame($path, $uri->getPath());
     }
 }


### PR DESCRIPTION
A call to `$uri->getScheme()` can return a `null`. The `UriFactory::factory()` method calls that method on the generated URI to determine the scheme, if any, in order to provide a more specific URI instance.  To do so, it passes the return value to `strtolower()`.  This raises a deprecation in PHP 8.1, as passing `null` to that function is now deprecated.
