### PR TITLE
Allow Laminas validator 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-escaper": "^2.9",
-        "laminas/laminas-validator": "^2.39"
+        "laminas/laminas-validator": "^2.39 || ^3.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "baee44930a09a18a6921bd62d91a97ab",
+    "content-hash": "d027ba487d40a7f2e2cf653c34b7e5e7",
     "packages": [
         {
             "name": "laminas/laminas-escaper",

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -1204,8 +1204,8 @@ class Uri implements UriInterface
         ];
 
         // Test only IPv4
-        $validator = new Validator\Ip($validatorParams);
-        $return    = $validator->isValid($host);
+        $validatorIpV4 = new Validator\Ip($validatorParams);
+        $return        = $validatorIpV4->isValid($host);
         if ($return) {
             return true;
         }
@@ -1218,8 +1218,8 @@ class Uri implements UriInterface
             'allowliteral'   => true,
         ];
         static $regex    = '/^\[.*\]$/';
-        $validator->setOptions($validatorParams);
-        return preg_match($regex, $host) && $validator->isValid($host);
+        $validatorIpV6   = new Validator\Ip($validatorParams);
+        return preg_match($regex, $host) && $validatorIpV6->isValid($host);
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no

### Description

Allow Laminas Validator v3 and remove the setOptions call for the IPv6 Validator.
This PR relates to https://github.com/laminas/laminas-http/pull/90 